### PR TITLE
Adds the option to change Overlays

### DIFF
--- a/MMM-windy.js
+++ b/MMM-windy.js
@@ -6,7 +6,8 @@ Module.register('MMM-windy', {
     particlesAnim: 'on',
     graticule: false,
     englishLabels: false,
-    hourFormat: '12h'
+    hourFormat: '12h',
+    overlay: 'wind'
   },
   getScripts: function() {
     return [
@@ -72,6 +73,7 @@ Module.register('MMM-windy', {
         graticule: self.config.graticule,
         englishLabels: self.config.englishLabels,
         hourFormat: self.config.hourFormat,
+        overlay: self.config.overlay,
       };
       if (self.config.location) {
         options.lat = self.config.location.lat;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use the module, add the following to the modules array in your `config/config
 		graticule: false,	// optional
 		englishLabels: false, // optional
 		hourFormat: '12h', // optional
-		overlay: 'windy' //optional
+		overlay: 'wind' //optional
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To use the module, add the following to the modules array in your `config/config
 		graticule: false,	// optional
 		englishLabels: false, // optional
 		hourFormat: '12h' // optional
+		overlay: 'windy' //optional
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use the module, add the following to the modules array in your `config/config
 		particlesAnim: 'on',	// optional, turns particles animation on or off, default 'on'
 		graticule: false,	// optional
 		englishLabels: false, // optional
-		hourFormat: '12h' // optional
+		hourFormat: '12h', // optional
 		overlay: 'windy' //optional
 	}
 }


### PR DESCRIPTION
Allows you to change the overlay from the default Windy.
See your options here: https://api.windy.com/map-forecast under 'levels'.

Only wind, temperature, pressure are available for the free API.